### PR TITLE
Fix CI/CD pipeline by updating GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -62,16 +62,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ env.PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
       
       - name: Authenticate Docker to Google Cloud Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
       
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
@@ -104,16 +110,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ env.PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
       
       - name: Authenticate Docker to Google Cloud Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
       
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
This PR fixes the CI/CD pipeline by:\n\n1. Adding the Docker Buildx setup step, which is required for cache support\n2. Updating the Google Cloud authentication to use the latest actions\n\nThese changes should allow the workflow to successfully build and push Docker images to Google Cloud Artifact Registry, and then deploy to Cloud Run.