### PR TITLE
Fix Dockerfile by adding public directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
+# Create public directory if it doesn't exist
+RUN mkdir -p ./public
 COPY --from=builder /app/public ./public
 
 # Set the correct permission for prerender cache

--- a/public/.gitkeep
+++ b/public/.gitkeep
@@ -1,0 +1,1 @@
+# This file is used to ensure the public directory is created


### PR DESCRIPTION
This PR fixes the Docker build process by:\n\n1. Adding a public directory with a .gitkeep file to ensure it exists in the repository\n2. Modifying the Dockerfile to create the public directory if it doesn't exist\n\nThis resolves the error in the CI/CD pipeline where the build fails because the public directory is missing.