### PR TITLE
Update documentation with preview service information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,15 @@ The project uses GitHub Actions for continuous integration and deployment:
 
 Make sure all tests pass before creating a pull request.
 
+### Preview Environment
+
+The preview environment is available at:
+- **URL**: [https://preview-374802729603.us-central1.run.app](https://preview-374802729603.us-central1.run.app)
+- **Health Endpoint**: [https://preview-374802729603.us-central1.run.app/api/health](https://preview-374802729603.us-central1.run.app/api/health)
+- **MCP Endpoint**: [https://preview-374802729603.us-central1.run.app/api/mcp](https://preview-374802729603.us-central1.run.app/api/mcp)
+
+The preview environment is automatically updated when changes are merged into the main branch. You can use it to test your changes before deploying to production.
+
 ## Project Phases
 
 The project is divided into three phases:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ These specification documents serve as the source of truth for the project's pur
 
 This project is currently in development. See [PLAN.md](./PLAN.md) for the roadmap and development phases, and the [GitHub Issues](https://github.com/bhouston/agentic-readme/issues) for specific tasks.
 
+### Preview Environment
+
+A preview environment is available at:
+- **URL**: [https://preview-374802729603.us-central1.run.app](https://preview-374802729603.us-central1.run.app)
+- **Health Endpoint**: [https://preview-374802729603.us-central1.run.app/api/health](https://preview-374802729603.us-central1.run.app/api/health)
+- **MCP Endpoint**: [https://preview-374802729603.us-central1.run.app/api/mcp](https://preview-374802729603.us-central1.run.app/api/mcp)
+
+The preview environment is automatically updated when changes are merged into the main branch.
+
 ## License
 
 MIT


### PR DESCRIPTION
This PR updates the documentation to include information about the preview service:\n\n1. Added a new section to README.md with the preview service URL and endpoints\n2. Updated CONTRIBUTING.md with information about the preview environment\n\nThis makes it easier for users and contributors to find and use the preview service.